### PR TITLE
Update 06_loadRoutes.js

### DIFF
--- a/init/06_loadRoutes.js
+++ b/init/06_loadRoutes.js
@@ -66,11 +66,6 @@ module.exports = function (app, options, siteSandal, renderTemplate) {
 					template: jsFile.replace(/\.js$/i, '.html')
 				});
 			});
-			routes.sort(function (a, b) {
-				a.sortOrder = a.sortOrder || 0;
-				b.sortOrder = b.sortOrder || 0;
-				return a.sortOrder - b.sortOrder;
-			});
 
 			async.eachSeries(routes, function (route, routeCallback) {
 				if (typeof route.backend === 'function') {


### PR DESCRIPTION
Remove sort which resulted unexpected order.
This sort is essentially doing something like .sort(function() { return 0; });, and result is undefined.

It would be nicer if we can send in sortOrder from each route but I don't have a good proposal for it.
